### PR TITLE
Fix broken link on hacky thursdays

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -53,7 +53,7 @@ data haystack, the wider background and broader perspective the better.
 The DAPLAB follows this reality and is thus open to everyone,
 the only requirement is to have a computer :).
 
-We also meet every [Thursday evening](hacky_thursday.md) for hacking data and discuss
+We also meet every [Thursday evening](hacky_thursdays.md) for hacking data and discuss
 about various hadoop-related technologies. Feel free to join us !
 
 


### PR DESCRIPTION
Hello,

On https://docs.daplab.ch/ the link goes to https://docs.daplab.ch/hacky_thursday.md , I believe it's because of this typo on the filename, although I didn't had time to test it 👶 .

Cheers,
Reynald
